### PR TITLE
fix a bad request error when using DynamoDB

### DIFF
--- a/v1/backends/dynamodb.go
+++ b/v1/backends/dynamodb.go
@@ -343,7 +343,7 @@ func (b *DynamoDBBackend) setTaskState(taskState *tasks.TaskState) error {
 		}
 		exp += ", #C = :c"
 	}
-	if taskState.Results != nil {
+	if taskState.Results != nil && len(taskState.Results) != 0 {
 		expAttributeNames["#R"] = aws.String("Results")
 		var results []*dynamodb.AttributeValue
 		for _, r := range taskState.Results {


### PR DESCRIPTION
Error:
```
worker.go:61 Broker failed with error: Set state success error: ValidationException: ExpressionAttributeValues contains invalid value: Supplied AttributeValue is empty, must contain exactly one of the supported datatypes for key :r
	status code: 400, request id: K86GJKCLN4S18RR32B2UA1MQCVVV4KQNSO5AEMVJF66Q9ASUAAJG
```
I've checked the condition of being ```Nil```, but I didn't expect that ```taskState.Results``` would be created as ```[]``` when there is no result returned by the worker. 